### PR TITLE
Fix Invalid date during conversion

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 function processEvent(event) {
-    if (event.properties && event.properties['$time']) {
-        const timestamp = isNaN(event.properties['$time']) ? event.properties['$time']: event.properties['$time'] * 1000
+    if (event.properties && event.properties['$time'] && !isNaN(event.properties['$time'])) {
+        const timestamp = event.properties['$time'] * 1000
         const eventDate = new Date(timestamp)
         event.properties['day_of_the_week'] = eventDate.toLocaleDateString('en-GB', { weekday: 'long' })
         const date = eventDate.toLocaleDateString('en-GB').split('/')

--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 function processEvent(event) {
     if (event.properties && event.properties['$time']) {
-        const timestamp = event.properties['$time'] * 1000
-        event.properties['day_of_the_week'] = new Date(timestamp).toLocaleDateString('en-GB', { weekday: 'long' })
-        const date = new Date(timestamp).toLocaleDateString('en-GB').split('/')
-        event.properties['day'] = Number(date[0])
-        event.properties['month'] = Number(date[1])
-        event.properties['year'] = Number(date[2])
+        const timestamp = isNaN(event.properties['$time']) ? event.properties['$time']: event.properties['$time'] * 1000
+        let date = new Date(timestamp)
+        event.properties['day_of_the_week'] = date.toLocaleDateString('en-GB', { weekday: 'long' })
+        date = date.toLocaleDateString('en-GB').split('/')
+        event.properties['day'] = date[0]
+        event.properties['month'] = date[1]
+        event.properties['year'] = date[2]
     }
 
     return event


### PR DESCRIPTION
Posthog usually stores $time values as ISO 8601 strings (not timestamps). 

With this commit, it starts supporting both timestamps and ISO 8601 strings.

Also the test was expecting strings but the function was casting the values to numbers. This is fixed so, assuming it's better to use strings.